### PR TITLE
New replaces NewClient + cleanups

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package zammad
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,28 +13,6 @@ import (
 // client uses a timeout of 5 seconds.
 func New(URL string) *Client {
 	return &Client{Client: &http.Client{Timeout: 5 * time.Second}, Url: URL}
-}
-
-func NewClient(client *Client) (*Client, error) {
-	if client.Url == "" {
-		return nil, errors.New("APIBase is required to create a Client")
-	}
-
-	if (client.Username == "" || client.Password == "") && client.Token == "" && client.OAuth == "" {
-		return nil, errors.New("Username and password, token or OAuth2 are required to create a Client")
-	}
-
-	if (client.Username != "" || client.Password != "") && (client.Token != "" || client.OAuth != "") {
-		return nil, errors.New("Only one authentication type between username and password, token and OAuth is supported")
-	}
-
-	if client.Token != "" && client.OAuth != "" {
-		return nil, errors.New("Only one between token and oauth must be specified")
-	}
-
-	client.Client = &http.Client{}
-
-	return client, nil
 }
 
 // NewRequest constructs a request and converts the payload to JSON.
@@ -65,9 +42,9 @@ func (c *Client) NewRequest(method, url string, payload interface{}) (*http.Requ
 	return req, nil
 }
 
-// Send makes a request to the API, the response body will be unmarshaled into v, or if v is an io.Writer, the response
+// send makes a request to the API, the response body will be unmarshaled into v, or if v is an io.Writer, the response
 // will be written to it without decoding. This can be helpful when debugging.
-func (c *Client) Send(req *http.Request, v interface{}) error {
+func (c *Client) send(req *http.Request, v interface{}) error {
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		return err
@@ -103,8 +80,8 @@ func (c *Client) Send(req *http.Request, v interface{}) error {
 	return json.NewDecoder(resp.Body).Decode(v)
 }
 
-// SendWithAuth makes a request to the API and apply the proper authentication header automatically.
-func (c *Client) SendWithAuth(req *http.Request, v interface{}) error {
+// sendWithAuth makes a request to the API and apply the proper authentication header automatically.
+func (c *Client) sendWithAuth(req *http.Request, v interface{}) error {
 	//Detect Authentication Type
 	if c.Username != "" && c.Password != "" {
 		req.SetBasicAuth(c.Username, c.Password)
@@ -116,5 +93,5 @@ func (c *Client) SendWithAuth(req *http.Request, v interface{}) error {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.OAuth))
 	}
 
-	return c.Send(req, v)
+	return c.send(req, v)
 }

--- a/group.go
+++ b/group.go
@@ -28,7 +28,7 @@ func (c *Client) GroupList() ([]Group, error) {
 		return nil, err
 	}
 
-	if err = c.SendWithAuth(req, &groups); err != nil {
+	if err = c.sendWithAuth(req, &groups); err != nil {
 		return nil, err
 	}
 
@@ -43,7 +43,7 @@ func (c *Client) GroupShow(groupID int) (Group, error) {
 		return group, err
 	}
 
-	if err = c.SendWithAuth(req, &group); err != nil {
+	if err = c.sendWithAuth(req, &group); err != nil {
 		return group, err
 	}
 
@@ -58,7 +58,7 @@ func (c *Client) GroupCreate(g Group) (Group, error) {
 		return group, err
 	}
 
-	if err = c.SendWithAuth(req, &group); err != nil {
+	if err = c.sendWithAuth(req, &group); err != nil {
 		return group, err
 	}
 
@@ -73,7 +73,7 @@ func (c *Client) GroupUpdate(groupID int, g Group) (Group, error) {
 		return group, err
 	}
 
-	if err = c.SendWithAuth(req, &group); err != nil {
+	if err = c.sendWithAuth(req, &group); err != nil {
 		return group, err
 	}
 
@@ -87,7 +87,7 @@ func (c *Client) GroupDelete(groupID int) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 

--- a/object.go
+++ b/object.go
@@ -17,7 +17,7 @@ func (c *Client) ObjectList() ([]Object, error) {
 		return objects, err
 	}
 
-	if err = c.SendWithAuth(req, objects); err != nil {
+	if err = c.sendWithAuth(req, objects); err != nil {
 		return objects, err
 	}
 
@@ -32,7 +32,7 @@ func (c *Client) ObjectShow(objectID int) (Object, error) {
 		return object, err
 	}
 
-	if err = c.SendWithAuth(req, object); err != nil {
+	if err = c.sendWithAuth(req, object); err != nil {
 		return object, err
 	}
 
@@ -47,7 +47,7 @@ func (c *Client) ObjectCreate(o Object) (Object, error) {
 		return object, err
 	}
 
-	if err = c.SendWithAuth(req, object); err != nil {
+	if err = c.sendWithAuth(req, object); err != nil {
 		return object, err
 	}
 
@@ -62,7 +62,7 @@ func (c *Client) ObjectUpdate(objectID int, o Object) (Object, error) {
 		return object, err
 	}
 
-	if err = c.SendWithAuth(req, object); err != nil {
+	if err = c.sendWithAuth(req, object); err != nil {
 		return object, err
 	}
 
@@ -76,7 +76,7 @@ func (c *Client) ObjectExecuteDatabaseMigration() error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 

--- a/online_notification.go
+++ b/online_notification.go
@@ -27,7 +27,7 @@ func (c *Client) OnlineNotificationList() ([]OnlineNotification, error) {
 		return notifications, err
 	}
 
-	if err = c.SendWithAuth(req, &notifications); err != nil {
+	if err = c.sendWithAuth(req, &notifications); err != nil {
 		return notifications, err
 	}
 
@@ -42,7 +42,7 @@ func (c *Client) OnlineNotificationShow(notificationID int) (OnlineNotification,
 		return notification, err
 	}
 
-	if err = c.SendWithAuth(req, &notification); err != nil {
+	if err = c.sendWithAuth(req, &notification); err != nil {
 		return notification, err
 	}
 
@@ -57,7 +57,7 @@ func (c *Client) OnlineNotificationUpdate(notificationID int, n OnlineNotificati
 		return notification, err
 	}
 
-	if err = c.SendWithAuth(req, notification); err != nil {
+	if err = c.sendWithAuth(req, notification); err != nil {
 		return notification, err
 	}
 
@@ -71,7 +71,7 @@ func (c *Client) OnlineNotificationDelete(notificationID int) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 
@@ -85,7 +85,7 @@ func (c *Client) OnlineNotificationMarkAllAsRead() error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 

--- a/organization.go
+++ b/organization.go
@@ -31,7 +31,7 @@ func (c *Client) OrganizationList() ([]Organization, error) {
 		return organizations, err
 	}
 
-	if err = c.SendWithAuth(req, &organizations); err != nil {
+	if err = c.sendWithAuth(req, &organizations); err != nil {
 		return organizations, err
 	}
 
@@ -46,7 +46,7 @@ func (c *Client) OrganizationSearch(query string, limit int) ([]Organization, er
 		return organizations, err
 	}
 
-	if err = c.SendWithAuth(req, &organizations); err != nil {
+	if err = c.sendWithAuth(req, &organizations); err != nil {
 		return organizations, err
 	}
 
@@ -61,7 +61,7 @@ func (c *Client) OrganizationShow(organizationID int) (Organization, error) {
 		return organization, err
 	}
 
-	if err = c.SendWithAuth(req, &organization); err != nil {
+	if err = c.sendWithAuth(req, &organization); err != nil {
 		return organization, err
 	}
 
@@ -76,7 +76,7 @@ func (c *Client) OrganizationCreate(o Organization) (Organization, error) {
 		return organization, err
 	}
 
-	if err = c.SendWithAuth(req, &organization); err != nil {
+	if err = c.sendWithAuth(req, &organization); err != nil {
 		return organization, err
 	}
 
@@ -91,7 +91,7 @@ func (c *Client) OrganizationUpdate(organizationID int, o Organization) (Organiz
 		return organization, err
 	}
 
-	if err = c.SendWithAuth(req, &organization); err != nil {
+	if err = c.sendWithAuth(req, &organization); err != nil {
 		return organization, err
 	}
 
@@ -105,7 +105,7 @@ func (c *Client) OrganizationDelete(organizationID int) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 

--- a/tags.go
+++ b/tags.go
@@ -16,7 +16,7 @@ func (c *Client) TagSearch(term string) ([]Tag, error) {
 		return nil, err
 	}
 
-	if err = c.SendWithAuth(req, &tags); err != nil {
+	if err = c.sendWithAuth(req, &tags); err != nil {
 		return nil, err
 	}
 
@@ -30,7 +30,7 @@ func (c *Client) TagAdd(t Tag) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 
@@ -44,7 +44,7 @@ func (c *Client) TagRemove(t Tag) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 
@@ -59,7 +59,7 @@ func (c *Client) TagAdminList() ([]Tag, error) {
 		return nil, err
 	}
 
-	if err = c.SendWithAuth(req, &tags); err != nil {
+	if err = c.sendWithAuth(req, &tags); err != nil {
 		return nil, err
 	}
 
@@ -73,7 +73,7 @@ func (c *Client) TagAdminCreate(t Tag) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 
@@ -87,7 +87,7 @@ func (c *Client) TagAdminRename(tagID int, t Tag) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 
@@ -101,7 +101,7 @@ func (c *Client) TagAdminDelete(tagID int) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 

--- a/ticket.go
+++ b/ticket.go
@@ -36,7 +36,7 @@ func (c *Client) TicketList() ([]Ticket, error) {
 		return nil, err
 	}
 
-	if err = c.SendWithAuth(req, &tickets); err != nil {
+	if err = c.sendWithAuth(req, &tickets); err != nil {
 		return nil, err
 	}
 
@@ -62,7 +62,7 @@ func (c *Client) TicketSearch(query string, limit int) ([]Ticket, error) {
 		return nil, err
 	}
 
-	if err = c.SendWithAuth(req, &ticksearch); err != nil {
+	if err = c.sendWithAuth(req, &ticksearch); err != nil {
 		return nil, err
 	}
 
@@ -83,7 +83,7 @@ func (c *Client) TicketShow(ticketID int) (Ticket, error) {
 		return ticket, err
 	}
 
-	if err = c.SendWithAuth(req, &ticket); err != nil {
+	if err = c.sendWithAuth(req, &ticket); err != nil {
 		return ticket, err
 	}
 
@@ -98,7 +98,7 @@ func (c *Client) TicketCreate(t Ticket) (Ticket, error) {
 		return ticket, err
 	}
 
-	if err = c.SendWithAuth(req, &ticket); err != nil {
+	if err = c.sendWithAuth(req, &ticket); err != nil {
 		return ticket, err
 	}
 
@@ -113,7 +113,7 @@ func (c *Client) TicketUpdate(ticketID int, t Ticket) (Ticket, error) {
 		return ticket, err
 	}
 
-	if err = c.SendWithAuth(req, &ticket); err != nil {
+	if err = c.sendWithAuth(req, &ticket); err != nil {
 		return ticket, err
 	}
 
@@ -127,7 +127,7 @@ func (c *Client) TicketDelete(ticketID int) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 

--- a/ticket_article.go
+++ b/ticket_article.go
@@ -39,7 +39,7 @@ func (c *Client) TicketArticleByTicket(ticketID int) ([]TicketArticle, error) {
 		return ticketArticles, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketArticles); err != nil {
+	if err = c.sendWithAuth(req, &ticketArticles); err != nil {
 		return ticketArticles, err
 	}
 
@@ -54,7 +54,7 @@ func (c *Client) TicketArticleShow(ticketArticleID int) (TicketArticle, error) {
 		return ticketArticle, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketArticle); err != nil {
+	if err = c.sendWithAuth(req, &ticketArticle); err != nil {
 		return ticketArticle, err
 	}
 
@@ -69,7 +69,7 @@ func (c *Client) TicketArticleCreate(t TicketArticle) (TicketArticle, error) {
 		return ticketArticle, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketArticle); err != nil {
+	if err = c.sendWithAuth(req, &ticketArticle); err != nil {
 		return ticketArticle, err
 	}
 

--- a/ticket_priority.go
+++ b/ticket_priority.go
@@ -28,7 +28,7 @@ func (c *Client) TicketPriorityList() ([]TicketPriority, error) {
 		return ticketPriorities, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketPriorities); err != nil {
+	if err = c.sendWithAuth(req, &ticketPriorities); err != nil {
 		return ticketPriorities, err
 	}
 
@@ -43,7 +43,7 @@ func (c *Client) TicketPriorityShow(ticketPriorityID int) (TicketPriority, error
 		return ticketPriority, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketPriority); err != nil {
+	if err = c.sendWithAuth(req, &ticketPriority); err != nil {
 		return ticketPriority, err
 	}
 
@@ -58,7 +58,7 @@ func (c *Client) TicketPriorityCreate(t TicketPriority) (TicketPriority, error) 
 		return ticketPriority, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketPriority); err != nil {
+	if err = c.sendWithAuth(req, &ticketPriority); err != nil {
 		return ticketPriority, err
 	}
 
@@ -73,7 +73,7 @@ func (c *Client) TicketPriorityUpdate(ticketPriorityID int, t TicketPriority) (T
 		return ticketPriority, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketPriority); err != nil {
+	if err = c.sendWithAuth(req, &ticketPriority); err != nil {
 		return ticketPriority, err
 	}
 
@@ -87,7 +87,7 @@ func (c *Client) TicketPriorityDelete(ticketPriorityID int) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 

--- a/ticket_state.go
+++ b/ticket_state.go
@@ -27,7 +27,7 @@ func (c *Client) TicketStateList() ([]TicketState, error) {
 		return ticketStates, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketStates); err != nil {
+	if err = c.sendWithAuth(req, &ticketStates); err != nil {
 		return ticketStates, err
 	}
 
@@ -42,7 +42,7 @@ func (c *Client) TicketStateShow(ticketStateID int) (TicketState, error) {
 		return ticketState, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketState); err != nil {
+	if err = c.sendWithAuth(req, &ticketState); err != nil {
 		return ticketState, err
 	}
 
@@ -57,7 +57,7 @@ func (c *Client) TicketStateCreate(t TicketState) (TicketState, error) {
 		return ticketState, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketState); err != nil {
+	if err = c.sendWithAuth(req, &ticketState); err != nil {
 		return ticketState, err
 	}
 
@@ -72,7 +72,7 @@ func (c *Client) TicketStateUpdate(ticketStateID int, t TicketState) (TicketStat
 		return ticketState, err
 	}
 
-	if err = c.SendWithAuth(req, &ticketState); err != nil {
+	if err = c.sendWithAuth(req, &ticketState); err != nil {
 		return ticketState, err
 	}
 
@@ -86,7 +86,7 @@ func (c *Client) TicketStateDelete(ticketStateID int) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 

--- a/ticket_tag.go
+++ b/ticket_tag.go
@@ -12,7 +12,7 @@ func (c *Client) TicketTagByTicket(ticketID int) ([]Tag, error) {
 		return nil, err
 	}
 
-	if err = c.SendWithAuth(req, &tags); err != nil {
+	if err = c.sendWithAuth(req, &tags); err != nil {
 		return nil, err
 	}
 

--- a/types.go
+++ b/types.go
@@ -6,7 +6,9 @@ import (
 )
 
 type (
-	// Client is used to query Zammad. It is safe to use concurrently.
+	// Client is used to query Zammad. It is safe to use concurrently. If you (inadvertly) added
+	// multiple authencation options that will be applied in the order, basic auth, token based, and
+	// then oauth. Where the last one set, wins.
 	Client struct {
 		Client   Doer
 		Username string
@@ -20,7 +22,7 @@ type (
 		FromFunc func() string
 	}
 
-	// TODO: not used yet.
+	// ErrorResponse is the response returned by Zammad when an error occured.
 	ErrorResponse struct {
 		Description      string `json:"error"`
 		DescriptionHuman string `json:"error_human"`

--- a/user.go
+++ b/user.go
@@ -26,7 +26,7 @@ func (c *Client) UserMe() (User, error) {
 		return user, err
 	}
 
-	if err = c.SendWithAuth(req, &user); err != nil {
+	if err = c.sendWithAuth(req, &user); err != nil {
 		return user, err
 	}
 
@@ -41,7 +41,7 @@ func (c *Client) UserList() ([]User, error) {
 		return nil, err
 	}
 
-	if err = c.SendWithAuth(req, &users); err != nil {
+	if err = c.sendWithAuth(req, &users); err != nil {
 		return nil, err
 	}
 
@@ -56,7 +56,7 @@ func (c *Client) UserSearch(query string, limit int) ([]User, error) {
 		return nil, err
 	}
 
-	if err = c.SendWithAuth(req, &users); err != nil {
+	if err = c.sendWithAuth(req, &users); err != nil {
 		return nil, err
 	}
 
@@ -71,7 +71,7 @@ func (c *Client) UserShow(userID int) (User, error) {
 		return user, err
 	}
 
-	if err = c.SendWithAuth(req, &user); err != nil {
+	if err = c.sendWithAuth(req, &user); err != nil {
 		return user, err
 	}
 
@@ -86,7 +86,7 @@ func (c *Client) UserCreate(u User) (User, error) {
 		return user, err
 	}
 
-	if err = c.SendWithAuth(req, &user); err != nil {
+	if err = c.sendWithAuth(req, &user); err != nil {
 		return user, err
 	}
 
@@ -101,7 +101,7 @@ func (c *Client) UserUpdate(userID int, u User) (User, error) {
 		return user, err
 	}
 
-	if err = c.SendWithAuth(req, &user); err != nil {
+	if err = c.sendWithAuth(req, &user); err != nil {
 		return user, err
 	}
 
@@ -115,7 +115,7 @@ func (c *Client) UserDelete(userID int) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 

--- a/user_access_token.go
+++ b/user_access_token.go
@@ -69,7 +69,7 @@ func (c *Client) UserAccessTokenList() ([]UserAccessToken, error) {
 		return nil, err
 	}
 
-	if err = c.SendWithAuth(req, &tockList); err != nil {
+	if err = c.sendWithAuth(req, &tockList); err != nil {
 		return nil, err
 	}
 
@@ -90,7 +90,7 @@ func (c *Client) UserAccessTokenCreate(t UserAccessToken) (UserAccessToken, erro
 		return userAccessToken, err
 	}
 
-	if err = c.SendWithAuth(req, &userAccessToken); err != nil {
+	if err = c.sendWithAuth(req, &userAccessToken); err != nil {
 		return userAccessToken, err
 	}
 
@@ -104,7 +104,7 @@ func (c *Client) UserAccessTokenDelete(tokenID int) error {
 		return err
 	}
 
-	if err = c.SendWithAuth(req, nil); err != nil {
+	if err = c.sendWithAuth(req, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Use New instead of NewClient to be more idomatic. Some cleanups, make a few functions private that don't need to be exported. Document how the authentication is applied.

Takes the place of #15, mostly mechanical and easier the editing conflicts.

Closes: #15