### PR TITLE
Add pagination to list commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.23
 
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54
+          version: v1.55

--- a/README.md
+++ b/README.md
@@ -15,19 +15,30 @@ import (
 )
 
 func main() {
-    client := zammad.New("https://my-zammad-instance.com")
-    client.Token = "my-accces-token"
-    // or basic auth see godoc
+	client := zammad.New("https://my-zammad-instance.com")
+	client.Token = "my-accces-token"
+	// or basic auth see godoc
 
-    users, err := client.UserList() // Get all users
-    if err != nil {
-        log.Fatal(err)
-    }
+	users, err := client.UserList() // Get all users
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    user, err := client.UserShow(1)  // Get User with ID 1
-    if err != nil {
-        log.Fatal(err)
-    }
+	user, err := client.UserShow(1) // Get User with ID 1
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// to iterate over pages
+	ticketRes := client.TicketListResult(zammad.WithPerPage(50))
+	for ticketRes.Next() {
+		tickets, err := ticketRes.Fetch()
+		if err != nil {
+			log.Fatalf("failed: %s", err)
+		}
+
+		log.Printf("number of tickets: %d\n", len(tickets))
+	}
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AlessandroSechi/zammad-go
 
-go 1.22.4
+go 1.23
 
 require (
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/AlessandroSechi/zammad-go
 
 go 1.22.4
+
+require (
+	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f
+	github.com/mattn/go-sqlite3 v1.14.24
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f h1:gOO/tNZMjjvTKZWpY7YnXC72ULNLErRtp94LountVE8=
+github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/group.go
+++ b/group.go
@@ -2,6 +2,7 @@ package zammad
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -20,13 +21,27 @@ type Group struct {
 	UserIds            []int     `json:"user_ids"`
 }
 
+func (c *Client) GroupListListResult(opts ...Option) *Result[Group] {
+	return &Result[Group]{
+		res:     nil,
+		resFunc: c.GroupListWithOptions,
+		opts:    NewRequestOptions(opts...),
+	}
+}
+
 func (c *Client) GroupList() ([]Group, error) {
+	return c.GroupListListResult().FetchAll()
+}
+
+func (c *Client) GroupListWithOptions(ro RequestOptions) ([]Group, error) {
 	var groups []Group
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/groups"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/groups"), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	req.URL.RawQuery = ro.URLParams()
 
 	if err = c.sendWithAuth(req, &groups); err != nil {
 		return nil, err
@@ -38,7 +53,7 @@ func (c *Client) GroupList() ([]Group, error) {
 func (c *Client) GroupShow(groupID int) (Group, error) {
 	var group Group
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/groups/%d", groupID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/groups/%d", groupID)), nil)
 	if err != nil {
 		return group, err
 	}
@@ -53,7 +68,7 @@ func (c *Client) GroupShow(groupID int) (Group, error) {
 func (c *Client) GroupCreate(g Group) (Group, error) {
 	var group Group
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/groups"), g)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/groups"), g)
 	if err != nil {
 		return group, err
 	}
@@ -68,7 +83,7 @@ func (c *Client) GroupCreate(g Group) (Group, error) {
 func (c *Client) GroupUpdate(groupID int, g Group) (Group, error) {
 	var group Group
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/groups/%d", groupID)), g)
+	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/groups/%d", groupID)), g)
 	if err != nil {
 		return group, err
 	}
@@ -82,7 +97,7 @@ func (c *Client) GroupUpdate(groupID int, g Group) (Group, error) {
 
 func (c *Client) GroupDelete(groupID int) error {
 
-	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/groups/%d", groupID)), nil)
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/groups/%d", groupID)), nil)
 	if err != nil {
 		return err
 	}

--- a/object.go
+++ b/object.go
@@ -1,6 +1,9 @@
 package zammad
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 // Object represent a Zammad object. See https://docs.zammad.org/en/latest/api/object.html.
 // Also note the warning there:
@@ -9,13 +12,27 @@ import "fmt"
 //	to adjust any of Zammads default fields.
 type Object *map[string]interface{}
 
+func (c *Client) ObjectListResult(opts ...Option) *Result[Object] {
+	return &Result[Object]{
+		res:     nil,
+		resFunc: c.ObjectListWithOptions,
+		opts:    NewRequestOptions(opts...),
+	}
+}
+
 func (c *Client) ObjectList() ([]Object, error) {
+	return c.ObjectListResult().FetchAll()
+}
+
+func (c *Client) ObjectListWithOptions(ro RequestOptions) ([]Object, error) {
 	var objects []Object
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/object_manager_attributes"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/object_manager_attributes"), nil)
 	if err != nil {
 		return objects, err
 	}
+
+	req.URL.RawQuery = ro.URLParams()
 
 	if err = c.sendWithAuth(req, objects); err != nil {
 		return objects, err
@@ -27,7 +44,7 @@ func (c *Client) ObjectList() ([]Object, error) {
 func (c *Client) ObjectShow(objectID int) (Object, error) {
 	var object Object
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/object_manager_attributes/%d", objectID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/object_manager_attributes/%d", objectID)), nil)
 	if err != nil {
 		return object, err
 	}
@@ -42,7 +59,7 @@ func (c *Client) ObjectShow(objectID int) (Object, error) {
 func (c *Client) ObjectCreate(o Object) (Object, error) {
 	var object Object
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/object_manager_attributes"), o)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/object_manager_attributes"), o)
 	if err != nil {
 		return object, err
 	}
@@ -57,7 +74,7 @@ func (c *Client) ObjectCreate(o Object) (Object, error) {
 func (c *Client) ObjectUpdate(objectID int, o Object) (Object, error) {
 	var object Object
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/object_manager_attributes/%d", objectID)), o)
+	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/object_manager_attributes/%d", objectID)), o)
 	if err != nil {
 		return object, err
 	}
@@ -71,7 +88,7 @@ func (c *Client) ObjectUpdate(objectID int, o Object) (Object, error) {
 
 func (c *Client) ObjectExecuteDatabaseMigration() error {
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/object_manager_attributes_execute_migrations"), nil)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/object_manager_attributes_execute_migrations"), nil)
 	if err != nil {
 		return err
 	}

--- a/online_notification.go
+++ b/online_notification.go
@@ -2,6 +2,7 @@ package zammad
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -19,13 +20,27 @@ type OnlineNotification struct {
 	UpdatedAt      time.Time `json:"updated_at"`
 }
 
+func (c *Client) OnlineNotificationListResult(opts ...Option) *Result[OnlineNotification] {
+	return &Result[OnlineNotification]{
+		res:     nil,
+		resFunc: c.OnlineNotificationListWithOptions,
+		opts:    NewRequestOptions(opts...),
+	}
+}
+
 func (c *Client) OnlineNotificationList() ([]OnlineNotification, error) {
+	return c.OnlineNotificationListResult().FetchAll()
+}
+
+func (c *Client) OnlineNotificationListWithOptions(ro RequestOptions) ([]OnlineNotification, error) {
 	var notifications []OnlineNotification
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/online_notifications"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/online_notifications"), nil)
 	if err != nil {
 		return notifications, err
 	}
+
+	req.URL.RawQuery = ro.URLParams()
 
 	if err = c.sendWithAuth(req, &notifications); err != nil {
 		return notifications, err
@@ -37,7 +52,7 @@ func (c *Client) OnlineNotificationList() ([]OnlineNotification, error) {
 func (c *Client) OnlineNotificationShow(notificationID int) (OnlineNotification, error) {
 	var notification OnlineNotification
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/online_notifications/%d", notificationID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/online_notifications/%d", notificationID)), nil)
 	if err != nil {
 		return notification, err
 	}
@@ -52,7 +67,7 @@ func (c *Client) OnlineNotificationShow(notificationID int) (OnlineNotification,
 func (c *Client) OnlineNotificationUpdate(notificationID int, n OnlineNotification) (OnlineNotification, error) {
 	var notification OnlineNotification
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/online_notifications/%d", notificationID)), n)
+	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/online_notifications/%d", notificationID)), n)
 	if err != nil {
 		return notification, err
 	}
@@ -66,7 +81,7 @@ func (c *Client) OnlineNotificationUpdate(notificationID int, n OnlineNotificati
 
 func (c *Client) OnlineNotificationDelete(notificationID int) error {
 
-	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/online_notifications/%d", notificationID)), nil)
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/online_notifications/%d", notificationID)), nil)
 	if err != nil {
 		return err
 	}
@@ -80,7 +95,7 @@ func (c *Client) OnlineNotificationDelete(notificationID int) error {
 
 func (c *Client) OnlineNotificationMarkAllAsRead() error {
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/online_notifications/mark_all_as_read"), nil)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/online_notifications/mark_all_as_read"), nil)
 	if err != nil {
 		return err
 	}

--- a/organization.go
+++ b/organization.go
@@ -2,6 +2,7 @@ package zammad
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"time"
 )
@@ -24,13 +25,27 @@ type Organization struct {
 	SecondaryMemberIds []int     `json:"secondary_member_ids,omitempty"`
 }
 
+func (c *Client) OrganizationListResult(opts ...Option) *Result[Organization] {
+	return &Result[Organization]{
+		res:     nil,
+		resFunc: c.OrganizationListWithOptions,
+		opts:    NewRequestOptions(opts...),
+	}
+}
+
 func (c *Client) OrganizationList() ([]Organization, error) {
+	return c.OrganizationListResult().FetchAll()
+}
+
+func (c *Client) OrganizationListWithOptions(ro RequestOptions) ([]Organization, error) {
 	var organizations []Organization
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/organizations"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/organizations"), nil)
 	if err != nil {
 		return organizations, err
 	}
+
+	req.URL.RawQuery = ro.URLParams()
 
 	if err = c.sendWithAuth(req, &organizations); err != nil {
 		return organizations, err
@@ -42,7 +57,7 @@ func (c *Client) OrganizationList() ([]Organization, error) {
 func (c *Client) OrganizationSearch(query string, limit int) ([]Organization, error) {
 	var organizations []Organization
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/search?query=%slimit=%d", url.QueryEscape(query), limit)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/search?query=%slimit=%d", url.QueryEscape(query), limit)), nil)
 	if err != nil {
 		return organizations, err
 	}
@@ -57,7 +72,7 @@ func (c *Client) OrganizationSearch(query string, limit int) ([]Organization, er
 func (c *Client) OrganizationShow(organizationID int) (Organization, error) {
 	var organization Organization
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/%d", organizationID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/%d", organizationID)), nil)
 	if err != nil {
 		return organization, err
 	}
@@ -72,7 +87,7 @@ func (c *Client) OrganizationShow(organizationID int) (Organization, error) {
 func (c *Client) OrganizationCreate(o Organization) (Organization, error) {
 	var organization Organization
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/organizations"), o)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/organizations"), o)
 	if err != nil {
 		return organization, err
 	}
@@ -87,7 +102,7 @@ func (c *Client) OrganizationCreate(o Organization) (Organization, error) {
 func (c *Client) OrganizationUpdate(organizationID int, o Organization) (Organization, error) {
 	var organization Organization
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/%d", organizationID)), o)
+	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/%d", organizationID)), o)
 	if err != nil {
 		return organization, err
 	}
@@ -101,7 +116,7 @@ func (c *Client) OrganizationUpdate(organizationID int, o Organization) (Organiz
 
 func (c *Client) OrganizationDelete(organizationID int) error {
 
-	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/%d", organizationID)), nil)
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/%d", organizationID)), nil)
 	if err != nil {
 		return err
 	}

--- a/organization_test.go
+++ b/organization_test.go
@@ -24,7 +24,7 @@ func TestOrganization(t *testing.T) {
 			var outerr error
 			switch tt.Func {
 			case "OrganizationList":
-				ts, err := z.OrganizationList()
+				ts, err := z.OrganizationList(NewRequestOptions())
 				if len(ts) != tt.Expect {
 					t.Errorf("expected %d tickets, got %d", tt.Expect, len(ts))
 				}

--- a/organization_test.go
+++ b/organization_test.go
@@ -24,7 +24,7 @@ func TestOrganization(t *testing.T) {
 			var outerr error
 			switch tt.Func {
 			case "OrganizationList":
-				ts, err := z.OrganizationList(NewRequestOptions())
+				ts, err := z.OrganizationList()
 				if len(ts) != tt.Expect {
 					t.Errorf("expected %d tickets, got %d", tt.Expect, len(ts))
 				}

--- a/organization_test.go
+++ b/organization_test.go
@@ -19,7 +19,8 @@ func TestOrganization(t *testing.T) {
 	z := &Client{}
 	for i, tt := range organizationTests {
 		data, _ := os.ReadFile(path.Join("testdata", tt.File))
-		z.Client = testClient{body: data}
+		z.Client = testClient{body: data, pages: 1}
+
 		t.Run(fmt.Sprintf("%0d-%s", i, tt.Func), func(t *testing.T) {
 			var outerr error
 			switch tt.Func {

--- a/requestoptions.go
+++ b/requestoptions.go
@@ -1,0 +1,81 @@
+package zammad
+
+import (
+	"net/url"
+	"strconv"
+)
+
+// RequestOptions holds the parameters for making a request.
+type RequestOptions struct {
+	page    int    // Page number for pagination
+	perPage int    // Number of items per page
+	sortBy  string // Field to sort by
+	orderBy string // Order of sorting (e.g., asc, desc)
+}
+
+// NewRequestOptions creates a new RequestOptions instance with the provided options.
+// It applies each Option function to the RequestOptions instance.
+func NewRequestOptions(opts ...Option) RequestOptions {
+	// set default for page/perPage as enforced by the API
+	ro := RequestOptions{}
+
+	for _, opt := range opts {
+		opt(&ro)
+	}
+
+	return ro
+}
+
+// URLParams returns the URL-encoded parameters for the request.
+func (ro RequestOptions) URLParams() string {
+	params := url.Values{}
+
+	if ro.page > 0 {
+		params.Set("page", strconv.Itoa(ro.page))
+	}
+
+	if ro.perPage > 0 {
+		params.Set("per_page", strconv.Itoa(ro.perPage))
+	}
+
+	if ro.sortBy != "" {
+		params.Set("sort_by", ro.sortBy)
+	}
+
+	if ro.orderBy != "" {
+		params.Set("order_by", ro.orderBy)
+	}
+
+	return params.Encode()
+}
+
+// Option is a function that modifies a RequestOptions instance.
+type Option func(ro *RequestOptions)
+
+// WithPage sets the page number in RequestOptions.
+func WithPage(page int) Option {
+	return func(ro *RequestOptions) {
+		ro.page = page
+	}
+}
+
+// WithPerPage sets the number of items per page in RequestOptions.
+func WithPerPage(perPage int) Option {
+	return func(ro *RequestOptions) {
+		ro.perPage = perPage
+	}
+}
+
+// WithOrderBy sets the order of sorting in RequestOptions.
+func WithOrderBy(orderBy string) Option {
+	return func(ro *RequestOptions) {
+		ro.orderBy = orderBy
+	}
+}
+
+// WithSortBy sets the field to sort by in RequestOptions.
+func WithSortBy(sortBy string) Option {
+	return func(ro *RequestOptions) {
+		ro.sortBy = sortBy
+	}
+}

--- a/requestoptions_test.go
+++ b/requestoptions_test.go
@@ -1,0 +1,27 @@
+package zammad
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestRequestOptions(t *testing.T) {
+	var requestOptionsTests = []struct {
+		opts   []Option
+		expect string
+	}{
+		{[]Option{WithPage(2), WithPerPage(50)}, "page=2&per_page=50"},
+		{[]Option{WithSortBy("name"), WithOrderBy("asc")}, "order_by=asc&sort_by=name"},
+		{[]Option{WithPage(2), WithPerPage(50), WithSortBy("date"), WithOrderBy("desc")}, "order_by=desc&page=2&per_page=50&sort_by=date"},
+	}
+
+	for _, tt := range requestOptionsTests {
+		t.Run(url.QueryEscape(tt.expect), func(t *testing.T) {
+			ro := NewRequestOptions(tt.opts...)
+			params := ro.URLParams()
+			if params != tt.expect {
+				t.Errorf("expected %s, got %s", tt.expect, params)
+			}
+		})
+	}
+}

--- a/result.go
+++ b/result.go
@@ -1,0 +1,54 @@
+package zammad
+
+// Result is a generic type that holds a slice of results and provides methods
+// to paginate through them.
+type Result[T any] struct {
+	res     []T                                       // Slice of results of type T
+	resFunc func(options RequestOptions) ([]T, error) // Function to fetch results based on RequestOptions
+	opts    RequestOptions                            // Options for the request
+	lastErr error                                     // Last error encountered during fetching
+}
+
+// Next fetches the next page of results. It returns false if there are no more
+// results to fetch. If an error occurs during fetching, it sets the lastErr
+// field and returns true.
+func (tr *Result[T]) Next() bool {
+	res, err := tr.resFunc(tr.opts)
+	if err != nil {
+		tr.res = nil
+		tr.lastErr = err
+		return true
+	}
+
+	tr.opts.page++
+	tr.res = res
+
+	if len(res) == 0 {
+		return false
+	}
+
+	return true
+}
+
+// Fetch returns the current slice of results and the last error encountered.
+func (tr *Result[T]) Fetch() ([]T, error) {
+	return tr.res, tr.lastErr
+}
+
+// FetchAll fetches all pages of results and returns them as a single slice.
+// If an error occurs during fetching, it returns the results fetched so far
+// along with the error.
+func (tr *Result[T]) FetchAll() ([]T, error) {
+	resAll := make([]T, 0)
+
+	for tr.Next() {
+		res, err := tr.Fetch()
+		if err != nil {
+			return resAll, err
+		}
+
+		resAll = append(resAll, res...)
+	}
+
+	return resAll, nil
+}

--- a/result.go
+++ b/result.go
@@ -20,6 +20,10 @@ func (tr *Result[T]) Next() bool {
 		return true
 	}
 
+	if tr.opts.page == 0 {
+		tr.opts.page = 1
+	}
+
 	tr.opts.page++
 	tr.res = res
 

--- a/tags.go
+++ b/tags.go
@@ -2,6 +2,7 @@ package zammad
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 )
 
@@ -14,7 +15,7 @@ type Tag struct {
 func (c *Client) TagSearch(term string) ([]Tag, error) {
 	var tags []Tag
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tag_search?term=%s", url.QueryEscape(term))), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tag_search?term=%s", url.QueryEscape(term))), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +29,7 @@ func (c *Client) TagSearch(term string) ([]Tag, error) {
 
 func (c *Client) TagAdd(t Tag) error {
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/tags/add"), t)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/tags/add"), t)
 	if err != nil {
 		return err
 	}
@@ -42,7 +43,7 @@ func (c *Client) TagAdd(t Tag) error {
 
 func (c *Client) TagRemove(t Tag) error {
 
-	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, "/api/v1/tags/remove"), t)
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, "/api/v1/tags/remove"), t)
 	if err != nil {
 		return err
 	}
@@ -57,7 +58,7 @@ func (c *Client) TagRemove(t Tag) error {
 func (c *Client) TagAdminList() ([]Tag, error) {
 	var tags []Tag
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/tag_list"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/tag_list"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +72,7 @@ func (c *Client) TagAdminList() ([]Tag, error) {
 
 func (c *Client) TagAdminCreate(t Tag) error {
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/tag_list"), t)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/tag_list"), t)
 	if err != nil {
 		return err
 	}
@@ -85,7 +86,7 @@ func (c *Client) TagAdminCreate(t Tag) error {
 
 func (c *Client) TagAdminRename(tagID int, t Tag) error {
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tag_list/%d", tagID)), t)
+	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tag_list/%d", tagID)), t)
 	if err != nil {
 		return err
 	}
@@ -99,7 +100,7 @@ func (c *Client) TagAdminRename(tagID int, t Tag) error {
 
 func (c *Client) TagAdminDelete(tagID int) error {
 
-	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tag_list/%d", tagID)), nil)
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tag_list/%d", tagID)), nil)
 	if err != nil {
 		return err
 	}

--- a/ticket.go
+++ b/ticket.go
@@ -2,6 +2,7 @@ package zammad
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"time"
 )
@@ -33,13 +34,27 @@ type Ticket struct {
 	UpdatedAt             time.Time     `json:"updated_at,omitempty"`
 }
 
+func (c *Client) TicketListResult(opts ...Option) *Result[Ticket] {
+	return &Result[Ticket]{
+		res:     nil,
+		resFunc: c.TicketListWithOptions,
+		opts:    NewRequestOptions(opts...),
+	}
+}
+
 func (c *Client) TicketList() ([]Ticket, error) {
+	return c.TicketListResult().FetchAll()
+}
+
+func (c *Client) TicketListWithOptions(ro RequestOptions) ([]Ticket, error) {
 	var tickets []Ticket
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/tickets"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/tickets"), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	req.URL.RawQuery = ro.URLParams()
 
 	if err = c.sendWithAuth(req, &tickets); err != nil {
 		return nil, err
@@ -61,7 +76,7 @@ func (c *Client) TicketSearch(query string, limit int) ([]Ticket, error) {
 	}
 
 	var ticksearch TickSearch
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/search?query=%s&limit=%d", url.QueryEscape(query), limit)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/search?query=%s&limit=%d", url.QueryEscape(query), limit)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +97,7 @@ func (c *Client) TicketSearch(query string, limit int) ([]Ticket, error) {
 func (c *Client) TicketShow(ticketID int) (Ticket, error) {
 	var ticket Ticket
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), nil)
 	if err != nil {
 		return ticket, err
 	}
@@ -108,7 +123,7 @@ func (c *Client) TicketShow(ticketID int) (Ticket, error) {
 func (c *Client) TicketCreate(t Ticket) (Ticket, error) {
 	var ticket Ticket
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/tickets"), t)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/tickets"), t)
 	if err != nil {
 		return ticket, err
 	}
@@ -123,7 +138,7 @@ func (c *Client) TicketCreate(t Ticket) (Ticket, error) {
 func (c *Client) TicketUpdate(ticketID int, t Ticket) (Ticket, error) {
 	var ticket Ticket
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), t)
+	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), t)
 	if err != nil {
 		return ticket, err
 	}
@@ -137,7 +152,7 @@ func (c *Client) TicketUpdate(ticketID int, t Ticket) (Ticket, error) {
 
 func (c *Client) TicketDelete(ticketID int) error {
 
-	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), nil)
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), nil)
 	if err != nil {
 		return err
 	}

--- a/ticket_article.go
+++ b/ticket_article.go
@@ -2,10 +2,11 @@ package zammad
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 )
 
-// TIcketArticle represents a Zammad ticket article.
+// TicketArticle represents a Zammad ticket article.
 type TicketArticle struct {
 	ID       int    `json:"id,omitempty"`
 	TicketID int    `json:"ticket_id,omitempty"`
@@ -34,7 +35,7 @@ type TicketArticle struct {
 func (c *Client) TicketArticleByTicket(ticketID int) ([]TicketArticle, error) {
 	var ticketArticles []TicketArticle
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_articles/by_ticket/%d", ticketID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_articles/by_ticket/%d", ticketID)), nil)
 	if err != nil {
 		return ticketArticles, err
 	}
@@ -49,7 +50,7 @@ func (c *Client) TicketArticleByTicket(ticketID int) ([]TicketArticle, error) {
 func (c *Client) TicketArticleShow(ticketArticleID int) (TicketArticle, error) {
 	var ticketArticle TicketArticle
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_articles/%d", ticketArticleID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_articles/%d", ticketArticleID)), nil)
 	if err != nil {
 		return ticketArticle, err
 	}
@@ -64,7 +65,7 @@ func (c *Client) TicketArticleShow(ticketArticleID int) (TicketArticle, error) {
 func (c *Client) TicketArticleCreate(t TicketArticle) (TicketArticle, error) {
 	var ticketArticle TicketArticle
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_articles"), t)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_articles"), t)
 	if err != nil {
 		return ticketArticle, err
 	}

--- a/ticket_priority.go
+++ b/ticket_priority.go
@@ -2,6 +2,7 @@ package zammad
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -20,13 +21,27 @@ type TicketPriority struct {
 	UpdatedAt     time.Time `json:"updated_at"`
 }
 
+func (c *Client) TicketPriorityListResult(opts ...Option) *Result[TicketPriority] {
+	return &Result[TicketPriority]{
+		res:     nil,
+		resFunc: c.TicketPriorityListWithOptions,
+		opts:    NewRequestOptions(opts...),
+	}
+}
+
 func (c *Client) TicketPriorityList() ([]TicketPriority, error) {
+	return c.TicketPriorityListResult().FetchAll()
+}
+
+func (c *Client) TicketPriorityListWithOptions(ro RequestOptions) ([]TicketPriority, error) {
 	var ticketPriorities []TicketPriority
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_priorities"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_priorities"), nil)
 	if err != nil {
 		return ticketPriorities, err
 	}
+
+	req.URL.RawQuery = ro.URLParams()
 
 	if err = c.sendWithAuth(req, &ticketPriorities); err != nil {
 		return ticketPriorities, err
@@ -38,7 +53,7 @@ func (c *Client) TicketPriorityList() ([]TicketPriority, error) {
 func (c *Client) TicketPriorityShow(ticketPriorityID int) (TicketPriority, error) {
 	var ticketPriority TicketPriority
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_priorities/%d", ticketPriorityID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_priorities/%d", ticketPriorityID)), nil)
 	if err != nil {
 		return ticketPriority, err
 	}
@@ -53,7 +68,7 @@ func (c *Client) TicketPriorityShow(ticketPriorityID int) (TicketPriority, error
 func (c *Client) TicketPriorityCreate(t TicketPriority) (TicketPriority, error) {
 	var ticketPriority TicketPriority
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_priorities"), t)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_priorities"), t)
 	if err != nil {
 		return ticketPriority, err
 	}
@@ -68,7 +83,7 @@ func (c *Client) TicketPriorityCreate(t TicketPriority) (TicketPriority, error) 
 func (c *Client) TicketPriorityUpdate(ticketPriorityID int, t TicketPriority) (TicketPriority, error) {
 	var ticketPriority TicketPriority
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_priorities/%d", ticketPriorityID)), t)
+	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_priorities/%d", ticketPriorityID)), t)
 	if err != nil {
 		return ticketPriority, err
 	}
@@ -82,7 +97,7 @@ func (c *Client) TicketPriorityUpdate(ticketPriorityID int, t TicketPriority) (T
 
 func (c *Client) TicketPriorityDelete(ticketPriorityID int) error {
 
-	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_priorities/%d", ticketPriorityID)), nil)
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_priorities/%d", ticketPriorityID)), nil)
 	if err != nil {
 		return err
 	}

--- a/ticket_state.go
+++ b/ticket_state.go
@@ -2,6 +2,7 @@ package zammad
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -19,13 +20,27 @@ type TicketState struct {
 	CreatedAt        time.Time `json:"created_at"`
 }
 
+func (c *Client) TicketStateListResult(opts ...Option) *Result[TicketState] {
+	return &Result[TicketState]{
+		res:     nil,
+		resFunc: c.TicketStateListWithOptions,
+		opts:    NewRequestOptions(opts...),
+	}
+}
+
 func (c *Client) TicketStateList() ([]TicketState, error) {
+	return c.TicketStateListResult().FetchAll()
+}
+
+func (c *Client) TicketStateListWithOptions(ro RequestOptions) ([]TicketState, error) {
 	var ticketStates []TicketState
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_states"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_states"), nil)
 	if err != nil {
 		return ticketStates, err
 	}
+
+	req.URL.RawQuery = ro.URLParams()
 
 	if err = c.sendWithAuth(req, &ticketStates); err != nil {
 		return ticketStates, err
@@ -37,7 +52,7 @@ func (c *Client) TicketStateList() ([]TicketState, error) {
 func (c *Client) TicketStateShow(ticketStateID int) (TicketState, error) {
 	var ticketState TicketState
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_states/%d", ticketStateID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_states/%d", ticketStateID)), nil)
 	if err != nil {
 		return ticketState, err
 	}
@@ -52,7 +67,7 @@ func (c *Client) TicketStateShow(ticketStateID int) (TicketState, error) {
 func (c *Client) TicketStateCreate(t TicketState) (TicketState, error) {
 	var ticketState TicketState
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_states"), t)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_states"), t)
 	if err != nil {
 		return ticketState, err
 	}
@@ -67,7 +82,7 @@ func (c *Client) TicketStateCreate(t TicketState) (TicketState, error) {
 func (c *Client) TicketStateUpdate(ticketStateID int, t TicketState) (TicketState, error) {
 	var ticketState TicketState
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_states/%d", ticketStateID)), t)
+	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_states/%d", ticketStateID)), t)
 	if err != nil {
 		return ticketState, err
 	}
@@ -81,7 +96,7 @@ func (c *Client) TicketStateUpdate(ticketStateID int, t TicketState) (TicketStat
 
 func (c *Client) TicketStateDelete(ticketStateID int) error {
 
-	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_states/%d", ticketStateID)), nil)
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_states/%d", ticketStateID)), nil)
 	if err != nil {
 		return err
 	}

--- a/ticket_tag.go
+++ b/ticket_tag.go
@@ -1,13 +1,16 @@
 package zammad
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func (c *Client) TicketTagByTicket(ticketID int) ([]Tag, error) {
 	var tags struct {
 		Tags []string
 	}
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tags?object=Ticket&o_id=%d", ticketID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tags?object=Ticket&o_id=%d", ticketID)), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ticket_test.go
+++ b/ticket_test.go
@@ -55,7 +55,7 @@ func TestTicket(t *testing.T) {
 			var outerr error
 			switch tt.Func {
 			case "TicketList":
-				ts, err := z.TicketList(NewRequestOptions())
+				ts, err := z.TicketList()
 				if len(ts) != tt.Expect {
 					t.Errorf("expected %d tickets, got %d", tt.Expect, len(ts))
 				}

--- a/ticket_test.go
+++ b/ticket_test.go
@@ -55,7 +55,7 @@ func TestTicket(t *testing.T) {
 			var outerr error
 			switch tt.Func {
 			case "TicketList":
-				ts, err := z.TicketList()
+				ts, err := z.TicketList(NewRequestOptions())
 				if len(ts) != tt.Expect {
 					t.Errorf("expected %d tickets, got %d", tt.Expect, len(ts))
 				}

--- a/user.go
+++ b/user.go
@@ -2,6 +2,7 @@ package zammad
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"time"
 )
@@ -22,7 +23,7 @@ type User struct {
 func (c *Client) UserMe() (User, error) {
 	var user User
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/users/me"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/users/me"), nil)
 	if err != nil {
 		return user, err
 	}
@@ -34,13 +35,27 @@ func (c *Client) UserMe() (User, error) {
 	return user, nil
 }
 
+func (c *Client) UserListResult(opts ...Option) *Result[User] {
+	return &Result[User]{
+		res:     nil,
+		resFunc: c.UserListWithOptions,
+		opts:    NewRequestOptions(opts...),
+	}
+}
+
 func (c *Client) UserList() ([]User, error) {
+	return c.UserListResult().FetchAll()
+}
+
+func (c *Client) UserListWithOptions(ro RequestOptions) ([]User, error) {
 	var users []User
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/users"), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/users"), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	req.URL.RawQuery = ro.URLParams()
 
 	if err = c.sendWithAuth(req, &users); err != nil {
 		return nil, err
@@ -52,7 +67,7 @@ func (c *Client) UserList() ([]User, error) {
 func (c *Client) UserSearch(query string, limit int) ([]User, error) {
 	var users []User
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/search?query=%s&limit=%d", url.QueryEscape(query), limit)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/search?query=%s&limit=%d", url.QueryEscape(query), limit)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +82,7 @@ func (c *Client) UserSearch(query string, limit int) ([]User, error) {
 func (c *Client) UserShow(userID int) (User, error) {
 	var user User
 
-	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/%d", userID)), nil)
+	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/%d", userID)), nil)
 	if err != nil {
 		return user, err
 	}
@@ -82,7 +97,7 @@ func (c *Client) UserShow(userID int) (User, error) {
 func (c *Client) UserCreate(u User) (User, error) {
 	var user User
 
-	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/users"), u)
+	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/users"), u)
 	if err != nil {
 		return user, err
 	}
@@ -97,7 +112,7 @@ func (c *Client) UserCreate(u User) (User, error) {
 func (c *Client) UserUpdate(userID int, u User) (User, error) {
 	var user User
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/%d", userID)), u)
+	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/%d", userID)), u)
 	if err != nil {
 		return user, err
 	}
@@ -111,7 +126,7 @@ func (c *Client) UserUpdate(userID int, u User) (User, error) {
 
 func (c *Client) UserDelete(userID int) error {
 
-	req, err := c.NewRequest("PUT", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/%d", userID)), nil)
+	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/%d", userID)), nil)
 	if err != nil {
 		return err
 	}

--- a/user_access_token.go
+++ b/user_access_token.go
@@ -2,7 +2,6 @@ package zammad
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 )
 
@@ -58,31 +57,17 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (c *Client) UserAccessTokenListResult(opts ...Option) *Result[UserAccessToken] {
-	return &Result[UserAccessToken]{
-		res:     nil,
-		resFunc: c.UserAccessTokenListWithOptions,
-		opts:    NewRequestOptions(opts...),
-	}
-}
-
 func (c *Client) UserAccessTokenList() ([]UserAccessToken, error) {
-	return c.UserAccessTokenListResult().FetchAll()
-}
-
-func (c *Client) UserAccessTokenListWithOptions(ro RequestOptions) ([]UserAccessToken, error) {
 	type TockList struct {
 		Tokens      []UserAccessToken `json:"tokens"`
 		Permissions []Permission      `json:"permissions"`
 	}
 
 	var tockList TockList
-	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/user_access_token"), nil)
+	req, err := c.NewRequest("GET", fmt.Sprintf("%s%s", c.Url, "/api/v1/user_access_token"), nil)
 	if err != nil {
 		return nil, err
 	}
-
-	req.URL.RawQuery = ro.URLParams()
 
 	if err = c.sendWithAuth(req, &tockList); err != nil {
 		return nil, err
@@ -100,7 +85,7 @@ func (c *Client) UserAccessTokenListWithOptions(ro RequestOptions) ([]UserAccess
 func (c *Client) UserAccessTokenCreate(t UserAccessToken) (UserAccessToken, error) {
 	var userAccessToken UserAccessToken
 
-	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/user_access_token"), t)
+	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/user_access_token"), t)
 	if err != nil {
 		return userAccessToken, err
 	}
@@ -114,7 +99,7 @@ func (c *Client) UserAccessTokenCreate(t UserAccessToken) (UserAccessToken, erro
 
 func (c *Client) UserAccessTokenDelete(tokenID int) error {
 
-	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/user_access_token/%d", tokenID)), nil)
+	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/user_access_token/%d", tokenID)), nil)
 	if err != nil {
 		return err
 	}

--- a/user_access_token_test.go
+++ b/user_access_token_test.go
@@ -25,7 +25,7 @@ func TestUserAccessToken(t *testing.T) {
 			var outerr error
 			switch tt.Func {
 			case "UserAccessTokenList":
-				ts, err := z.UserAccessTokenList()
+				ts, err := z.UserAccessTokenList(NewRequestOptions())
 				if len(ts) != tt.Expect {
 					t.Errorf("expected %d tokens, got %d", tt.Expect, len(ts))
 				}

--- a/user_access_token_test.go
+++ b/user_access_token_test.go
@@ -25,7 +25,7 @@ func TestUserAccessToken(t *testing.T) {
 			var outerr error
 			switch tt.Func {
 			case "UserAccessTokenList":
-				ts, err := z.UserAccessTokenList(NewRequestOptions())
+				ts, err := z.UserAccessTokenList()
 				if len(ts) != tt.Expect {
 					t.Errorf("expected %d tokens, got %d", tt.Expect, len(ts))
 				}

--- a/user_access_token_test.go
+++ b/user_access_token_test.go
@@ -20,7 +20,7 @@ func TestUserAccessToken(t *testing.T) {
 	z := &Client{}
 	for i, tt := range userAccessTokenTests {
 		data, _ := os.ReadFile(path.Join("testdata", tt.File))
-		z.Client = testClient{body: data}
+		z.Client = testClient{body: data, pages: 1}
 		t.Run(fmt.Sprintf("%0d-%s", i, tt.Func), func(t *testing.T) {
 			var outerr error
 			switch tt.Func {


### PR DESCRIPTION
This PR adds pagination to all list functions as well as sort by and order by support. I needed this as we had to deal with >2100 tickets so I took the opportunity to add this missing feature.

All normal list function signatures like `TicketList()` keep unchanged but they now use pagination under the hood. So this PR will not break compatibility but instead the list functions truly return all elements if there are >100.

For users that need more control there are new functions that return a "result" struct implemented in a generic way, for instance `TicketListResult()`. All those functions support options to set the desired page, items per page, sort by and order by.

```
ticketsRes := client.TicketListResult(zammad.WithPerPage(50))
```

The returned result struct has a function  `Next()` as proposed in #9 that can be used in a `for` loop to iterate over the result set. To retrieve the current results inside the loop you can use `Fetch()`. To retrieve all results at once use `FetchAll()`.

Fixes #9 
