### PR TITLE
Custom Field/Objects Support

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,8 +15,12 @@ func New(URL string) *Client {
 	return &Client{Client: &http.Client{Timeout: 5 * time.Second}, Url: URL}
 }
 
+func NewWithCustomTicketFields[T any](URL string) *client[T] {
+	return &client[T]{Client: &http.Client{Timeout: 5 * time.Second}, Url: URL}
+}
+
 // NewRequest constructs a request and converts the payload to JSON.
-func (c *Client) NewRequest(method, url string, payload interface{}) (*http.Request, error) {
+func (c *client[T]) NewRequest(method, url string, payload interface{}) (*http.Request, error) {
 	var buf io.Reader
 	if payload != nil {
 		b, err := json.Marshal(&payload)
@@ -44,7 +48,7 @@ func (c *Client) NewRequest(method, url string, payload interface{}) (*http.Requ
 
 // send makes a request to the API, the response body will be unmarshaled into v, or if v is an io.Writer, the response
 // will be written to it without decoding. This can be helpful when debugging.
-func (c *Client) send(req *http.Request, v interface{}) error {
+func (c *client[T]) send(req *http.Request, v interface{}) error {
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		return err
@@ -81,7 +85,7 @@ func (c *Client) send(req *http.Request, v interface{}) error {
 }
 
 // sendWithAuth makes a request to the API and apply the proper authentication header automatically.
-func (c *Client) sendWithAuth(req *http.Request, v interface{}) error {
+func (c *client[T]) sendWithAuth(req *http.Request, v interface{}) error {
 	//Detect Authentication Type
 	if c.Username != "" && c.Password != "" {
 		req.SetBasicAuth(c.Username, c.Password)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AlessandroSechi/zammad-go
+module github.com/michael-schmid-wlw/zammad-go
 
 go 1.23
 

--- a/group.go
+++ b/group.go
@@ -21,7 +21,7 @@ type Group struct {
 	UserIds            []int     `json:"user_ids"`
 }
 
-func (c *Client) GroupListListResult(opts ...Option) *Result[Group] {
+func (c *client[T]) GroupListListResult(opts ...Option) *Result[Group] {
 	return &Result[Group]{
 		res:     nil,
 		resFunc: c.GroupListWithOptions,
@@ -29,11 +29,11 @@ func (c *Client) GroupListListResult(opts ...Option) *Result[Group] {
 	}
 }
 
-func (c *Client) GroupList() ([]Group, error) {
+func (c *client[T]) GroupList() ([]Group, error) {
 	return c.GroupListListResult().FetchAll()
 }
 
-func (c *Client) GroupListWithOptions(ro RequestOptions) ([]Group, error) {
+func (c *client[T]) GroupListWithOptions(ro RequestOptions) ([]Group, error) {
 	var groups []Group
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/groups"), nil)
@@ -50,7 +50,7 @@ func (c *Client) GroupListWithOptions(ro RequestOptions) ([]Group, error) {
 	return groups, nil
 }
 
-func (c *Client) GroupShow(groupID int) (Group, error) {
+func (c *client[T]) GroupShow(groupID int) (Group, error) {
 	var group Group
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/groups/%d", groupID)), nil)
@@ -65,7 +65,7 @@ func (c *Client) GroupShow(groupID int) (Group, error) {
 	return group, nil
 }
 
-func (c *Client) GroupCreate(g Group) (Group, error) {
+func (c *client[T]) GroupCreate(g Group) (Group, error) {
 	var group Group
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/groups"), g)
@@ -80,7 +80,7 @@ func (c *Client) GroupCreate(g Group) (Group, error) {
 	return group, nil
 }
 
-func (c *Client) GroupUpdate(groupID int, g Group) (Group, error) {
+func (c *client[T]) GroupUpdate(groupID int, g Group) (Group, error) {
 	var group Group
 
 	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/groups/%d", groupID)), g)
@@ -95,7 +95,7 @@ func (c *Client) GroupUpdate(groupID int, g Group) (Group, error) {
 	return group, nil
 }
 
-func (c *Client) GroupDelete(groupID int) error {
+func (c *client[T]) GroupDelete(groupID int) error {
 
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/groups/%d", groupID)), nil)
 	if err != nil {

--- a/object.go
+++ b/object.go
@@ -12,7 +12,7 @@ import (
 //	to adjust any of Zammads default fields.
 type Object *map[string]interface{}
 
-func (c *Client) ObjectListResult(opts ...Option) *Result[Object] {
+func (c *client[T]) ObjectListResult(opts ...Option) *Result[Object] {
 	return &Result[Object]{
 		res:     nil,
 		resFunc: c.ObjectListWithOptions,
@@ -20,11 +20,11 @@ func (c *Client) ObjectListResult(opts ...Option) *Result[Object] {
 	}
 }
 
-func (c *Client) ObjectList() ([]Object, error) {
+func (c *client[T]) ObjectList() ([]Object, error) {
 	return c.ObjectListResult().FetchAll()
 }
 
-func (c *Client) ObjectListWithOptions(ro RequestOptions) ([]Object, error) {
+func (c *client[T]) ObjectListWithOptions(ro RequestOptions) ([]Object, error) {
 	var objects []Object
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/object_manager_attributes"), nil)
@@ -41,7 +41,7 @@ func (c *Client) ObjectListWithOptions(ro RequestOptions) ([]Object, error) {
 	return objects, nil
 }
 
-func (c *Client) ObjectShow(objectID int) (Object, error) {
+func (c *client[T]) ObjectShow(objectID int) (Object, error) {
 	var object Object
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/object_manager_attributes/%d", objectID)), nil)
@@ -56,7 +56,7 @@ func (c *Client) ObjectShow(objectID int) (Object, error) {
 	return object, nil
 }
 
-func (c *Client) ObjectCreate(o Object) (Object, error) {
+func (c *client[T]) ObjectCreate(o Object) (Object, error) {
 	var object Object
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/object_manager_attributes"), o)
@@ -71,7 +71,7 @@ func (c *Client) ObjectCreate(o Object) (Object, error) {
 	return object, nil
 }
 
-func (c *Client) ObjectUpdate(objectID int, o Object) (Object, error) {
+func (c *client[T]) ObjectUpdate(objectID int, o Object) (Object, error) {
 	var object Object
 
 	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/object_manager_attributes/%d", objectID)), o)
@@ -86,7 +86,7 @@ func (c *Client) ObjectUpdate(objectID int, o Object) (Object, error) {
 	return object, nil
 }
 
-func (c *Client) ObjectExecuteDatabaseMigration() error {
+func (c *client[T]) ObjectExecuteDatabaseMigration() error {
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/object_manager_attributes_execute_migrations"), nil)
 	if err != nil {

--- a/online_notification.go
+++ b/online_notification.go
@@ -20,7 +20,7 @@ type OnlineNotification struct {
 	UpdatedAt      time.Time `json:"updated_at"`
 }
 
-func (c *Client) OnlineNotificationListResult(opts ...Option) *Result[OnlineNotification] {
+func (c *client[T]) OnlineNotificationListResult(opts ...Option) *Result[OnlineNotification] {
 	return &Result[OnlineNotification]{
 		res:     nil,
 		resFunc: c.OnlineNotificationListWithOptions,
@@ -28,11 +28,11 @@ func (c *Client) OnlineNotificationListResult(opts ...Option) *Result[OnlineNoti
 	}
 }
 
-func (c *Client) OnlineNotificationList() ([]OnlineNotification, error) {
+func (c *client[T]) OnlineNotificationList() ([]OnlineNotification, error) {
 	return c.OnlineNotificationListResult().FetchAll()
 }
 
-func (c *Client) OnlineNotificationListWithOptions(ro RequestOptions) ([]OnlineNotification, error) {
+func (c *client[T]) OnlineNotificationListWithOptions(ro RequestOptions) ([]OnlineNotification, error) {
 	var notifications []OnlineNotification
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/online_notifications"), nil)
@@ -49,7 +49,7 @@ func (c *Client) OnlineNotificationListWithOptions(ro RequestOptions) ([]OnlineN
 	return notifications, nil
 }
 
-func (c *Client) OnlineNotificationShow(notificationID int) (OnlineNotification, error) {
+func (c *client[T]) OnlineNotificationShow(notificationID int) (OnlineNotification, error) {
 	var notification OnlineNotification
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/online_notifications/%d", notificationID)), nil)
@@ -64,7 +64,7 @@ func (c *Client) OnlineNotificationShow(notificationID int) (OnlineNotification,
 	return notification, nil
 }
 
-func (c *Client) OnlineNotificationUpdate(notificationID int, n OnlineNotification) (OnlineNotification, error) {
+func (c *client[T]) OnlineNotificationUpdate(notificationID int, n OnlineNotification) (OnlineNotification, error) {
 	var notification OnlineNotification
 
 	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/online_notifications/%d", notificationID)), n)
@@ -79,7 +79,7 @@ func (c *Client) OnlineNotificationUpdate(notificationID int, n OnlineNotificati
 	return notification, nil
 }
 
-func (c *Client) OnlineNotificationDelete(notificationID int) error {
+func (c *client[T]) OnlineNotificationDelete(notificationID int) error {
 
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/online_notifications/%d", notificationID)), nil)
 	if err != nil {
@@ -93,7 +93,7 @@ func (c *Client) OnlineNotificationDelete(notificationID int) error {
 	return nil
 }
 
-func (c *Client) OnlineNotificationMarkAllAsRead() error {
+func (c *client[T]) OnlineNotificationMarkAllAsRead() error {
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/online_notifications/mark_all_as_read"), nil)
 	if err != nil {

--- a/organization.go
+++ b/organization.go
@@ -25,7 +25,7 @@ type Organization struct {
 	SecondaryMemberIds []int     `json:"secondary_member_ids,omitempty"`
 }
 
-func (c *Client) OrganizationListResult(opts ...Option) *Result[Organization] {
+func (c *client[T]) OrganizationListResult(opts ...Option) *Result[Organization] {
 	return &Result[Organization]{
 		res:     nil,
 		resFunc: c.OrganizationListWithOptions,
@@ -33,11 +33,11 @@ func (c *Client) OrganizationListResult(opts ...Option) *Result[Organization] {
 	}
 }
 
-func (c *Client) OrganizationList() ([]Organization, error) {
+func (c *client[T]) OrganizationList() ([]Organization, error) {
 	return c.OrganizationListResult().FetchAll()
 }
 
-func (c *Client) OrganizationListWithOptions(ro RequestOptions) ([]Organization, error) {
+func (c *client[T]) OrganizationListWithOptions(ro RequestOptions) ([]Organization, error) {
 	var organizations []Organization
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/organizations"), nil)
@@ -54,7 +54,7 @@ func (c *Client) OrganizationListWithOptions(ro RequestOptions) ([]Organization,
 	return organizations, nil
 }
 
-func (c *Client) OrganizationSearch(query string, limit int) ([]Organization, error) {
+func (c *client[T]) OrganizationSearch(query string, limit int) ([]Organization, error) {
 	var organizations []Organization
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/search?query=%slimit=%d", url.QueryEscape(query), limit)), nil)
@@ -69,7 +69,7 @@ func (c *Client) OrganizationSearch(query string, limit int) ([]Organization, er
 	return organizations, nil
 }
 
-func (c *Client) OrganizationShow(organizationID int) (Organization, error) {
+func (c *client[T]) OrganizationShow(organizationID int) (Organization, error) {
 	var organization Organization
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/%d", organizationID)), nil)
@@ -84,7 +84,7 @@ func (c *Client) OrganizationShow(organizationID int) (Organization, error) {
 	return organization, nil
 }
 
-func (c *Client) OrganizationCreate(o Organization) (Organization, error) {
+func (c *client[T]) OrganizationCreate(o Organization) (Organization, error) {
 	var organization Organization
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/organizations"), o)
@@ -99,7 +99,7 @@ func (c *Client) OrganizationCreate(o Organization) (Organization, error) {
 	return organization, nil
 }
 
-func (c *Client) OrganizationUpdate(organizationID int, o Organization) (Organization, error) {
+func (c *client[T]) OrganizationUpdate(organizationID int, o Organization) (Organization, error) {
 	var organization Organization
 
 	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/%d", organizationID)), o)
@@ -114,7 +114,7 @@ func (c *Client) OrganizationUpdate(organizationID int, o Organization) (Organiz
 	return organization, nil
 }
 
-func (c *Client) OrganizationDelete(organizationID int) error {
+func (c *client[T]) OrganizationDelete(organizationID int) error {
 
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/organizations/%d", organizationID)), nil)
 	if err != nil {

--- a/tags.go
+++ b/tags.go
@@ -12,7 +12,7 @@ type Tag struct {
 	Name string `json:"name"`
 }
 
-func (c *Client) TagSearch(term string) ([]Tag, error) {
+func (c *client[T]) TagSearch(term string) ([]Tag, error) {
 	var tags []Tag
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tag_search?term=%s", url.QueryEscape(term))), nil)
@@ -27,7 +27,7 @@ func (c *Client) TagSearch(term string) ([]Tag, error) {
 	return tags, nil
 }
 
-func (c *Client) TagAdd(t Tag) error {
+func (c *client[T]) TagAdd(t Tag) error {
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/tags/add"), t)
 	if err != nil {
@@ -41,7 +41,7 @@ func (c *Client) TagAdd(t Tag) error {
 	return nil
 }
 
-func (c *Client) TagRemove(t Tag) error {
+func (c *client[T]) TagRemove(t Tag) error {
 
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, "/api/v1/tags/remove"), t)
 	if err != nil {
@@ -55,7 +55,7 @@ func (c *Client) TagRemove(t Tag) error {
 	return nil
 }
 
-func (c *Client) TagAdminList() ([]Tag, error) {
+func (c *client[T]) TagAdminList() ([]Tag, error) {
 	var tags []Tag
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/tag_list"), nil)
@@ -70,7 +70,7 @@ func (c *Client) TagAdminList() ([]Tag, error) {
 	return tags, nil
 }
 
-func (c *Client) TagAdminCreate(t Tag) error {
+func (c *client[T]) TagAdminCreate(t Tag) error {
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/tag_list"), t)
 	if err != nil {
@@ -84,7 +84,7 @@ func (c *Client) TagAdminCreate(t Tag) error {
 	return nil
 }
 
-func (c *Client) TagAdminRename(tagID int, t Tag) error {
+func (c *client[T]) TagAdminRename(tagID int, t Tag) error {
 
 	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tag_list/%d", tagID)), t)
 	if err != nil {
@@ -98,7 +98,7 @@ func (c *Client) TagAdminRename(tagID int, t Tag) error {
 	return nil
 }
 
-func (c *Client) TagAdminDelete(tagID int) error {
+func (c *client[T]) TagAdminDelete(tagID int) error {
 
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tag_list/%d", tagID)), nil)
 	if err != nil {

--- a/ticket.go
+++ b/ticket.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Ticket is a zammad ticket.
-type Ticket struct {
+type Ticket[Customfields any] struct {
 	Title                 string        `json:"title"`
 	Group                 string        `json:"group"`
 	OwnerID               int           `json:"owner_id,omitempty"`
@@ -32,22 +32,23 @@ type Ticket struct {
 	CreatedByID           int           `json:"created_by_id,omitempty"`
 	CreatedAt             time.Time     `json:"created_at,omitempty"`
 	UpdatedAt             time.Time     `json:"updated_at,omitempty"`
+	CustomFields          Customfields
 }
 
-func (c *Client) TicketListResult(opts ...Option) *Result[Ticket] {
-	return &Result[Ticket]{
+func (c *client[T]) TicketListResult(opts ...Option) *Result[Ticket[T]] {
+	return &Result[Ticket[T]]{
 		res:     nil,
 		resFunc: c.TicketListWithOptions,
 		opts:    NewRequestOptions(opts...),
 	}
 }
 
-func (c *Client) TicketList() ([]Ticket, error) {
+func (c *client[T]) TicketList() ([]Ticket[T], error) {
 	return c.TicketListResult().FetchAll()
 }
 
-func (c *Client) TicketListWithOptions(ro RequestOptions) ([]Ticket, error) {
-	var tickets []Ticket
+func (c *client[T]) TicketListWithOptions(ro RequestOptions) ([]Ticket[T], error) {
+	var tickets []Ticket[T]
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/tickets"), nil)
 	if err != nil {
@@ -64,9 +65,9 @@ func (c *Client) TicketListWithOptions(ro RequestOptions) ([]Ticket, error) {
 }
 
 // TicketSearch searches for tickets. See https://docs.zammad.org/en/latest/api/ticket/index.html#search.
-func (c *Client) TicketSearch(query string, limit int) ([]Ticket, error) {
+func (c *client[T]) TicketSearch(query string, limit int) ([]Ticket[T], error) {
 	type Assets struct {
-		AssetTicket map[int]Ticket `json:"ticket"`
+		AssetTicket map[int]Ticket[T] `json:"ticket"`
 	}
 
 	type TickSearch struct {
@@ -85,7 +86,7 @@ func (c *Client) TicketSearch(query string, limit int) ([]Ticket, error) {
 		return nil, err
 	}
 
-	tickets := make([]Ticket, ticksearch.Count)
+	tickets := make([]Ticket[T], ticksearch.Count)
 	i := 0
 	for _, t1 := range ticksearch.Assets.AssetTicket {
 		tickets[i] = t1
@@ -94,8 +95,8 @@ func (c *Client) TicketSearch(query string, limit int) ([]Ticket, error) {
 	return tickets, nil
 }
 
-func (c *Client) TicketShow(ticketID int) (Ticket, error) {
-	var ticket Ticket
+func (c *client[T]) TicketShow(ticketID int) (Ticket[T], error) {
+	var ticket Ticket[T]
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), nil)
 	if err != nil {
@@ -120,8 +121,8 @@ func (c *Client) TicketShow(ticketID int) (Ticket, error) {
 //			Body: "body of comment",
 //		},
 //	}
-func (c *Client) TicketCreate(t Ticket) (Ticket, error) {
-	var ticket Ticket
+func (c *client[T]) TicketCreate(t Ticket[T]) (Ticket[T], error) {
+	var ticket Ticket[T]
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/tickets"), t)
 	if err != nil {
@@ -135,8 +136,8 @@ func (c *Client) TicketCreate(t Ticket) (Ticket, error) {
 	return ticket, nil
 }
 
-func (c *Client) TicketUpdate(ticketID int, t Ticket) (Ticket, error) {
-	var ticket Ticket
+func (c *client[T]) TicketUpdate(ticketID int, t Ticket[T]) (Ticket[T], error) {
+	var ticket Ticket[T]
 
 	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), t)
 	if err != nil {
@@ -150,7 +151,7 @@ func (c *Client) TicketUpdate(ticketID int, t Ticket) (Ticket, error) {
 	return ticket, nil
 }
 
-func (c *Client) TicketDelete(ticketID int) error {
+func (c *client[T]) TicketDelete(ticketID int) error {
 
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), nil)
 	if err != nil {

--- a/ticket.go
+++ b/ticket.go
@@ -1,6 +1,7 @@
 package zammad
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -8,7 +9,7 @@ import (
 )
 
 // Ticket is a zammad ticket.
-type Ticket[Customfields any] struct {
+type Ticket[T any] struct {
 	Title                 string        `json:"title"`
 	Group                 string        `json:"group"`
 	OwnerID               int           `json:"owner_id,omitempty"`
@@ -32,7 +33,43 @@ type Ticket[Customfields any] struct {
 	CreatedByID           int           `json:"created_by_id,omitempty"`
 	CreatedAt             time.Time     `json:"created_at,omitempty"`
 	UpdatedAt             time.Time     `json:"updated_at,omitempty"`
-	CustomFields          Customfields
+	CustomFields          T             `json:"-"`
+}
+
+func (t *Ticket[T]) UnmarshalJSON(data []byte) error {
+	type TicketAlias Ticket[T]
+	if err := json.Unmarshal(data, (*TicketAlias)(t)); err != nil {
+		return err
+	}
+	return json.Unmarshal(data, &t.CustomFields)
+}
+
+func (t Ticket[T]) MarshalJSON() ([]byte, error) {
+	type TicketAlias Ticket[T]
+
+	baseBytes, err := json.Marshal(TicketAlias(t))
+	if err != nil {
+		return nil, err
+	}
+
+	customBytes, err := json.Marshal(t.CustomFields)
+	if err != nil {
+		return nil, err
+	}
+
+	var base, custom map[string]json.RawMessage
+	if err := json.Unmarshal(baseBytes, &base); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(customBytes, &custom); err != nil {
+		return nil, err
+	}
+
+	for k, v := range custom {
+		base[k] = v
+	}
+
+	return json.Marshal(base)
 }
 
 func (c *client[T]) TicketListResult(opts ...Option) *Result[Ticket[T]] {
@@ -152,7 +189,6 @@ func (c *client[T]) TicketUpdate(ticketID int, t Ticket[T]) (Ticket[T], error) {
 }
 
 func (c *client[T]) TicketDelete(ticketID int) error {
-
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/tickets/%d", ticketID)), nil)
 	if err != nil {
 		return err

--- a/ticket_article.go
+++ b/ticket_article.go
@@ -32,7 +32,7 @@ type TicketArticle struct {
 	UpdatedBy   string    `json:"updated_by,omitempty"`
 }
 
-func (c *Client) TicketArticleByTicket(ticketID int) ([]TicketArticle, error) {
+func (c *client[T]) TicketArticleByTicket(ticketID int) ([]TicketArticle, error) {
 	var ticketArticles []TicketArticle
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_articles/by_ticket/%d", ticketID)), nil)
@@ -47,7 +47,7 @@ func (c *Client) TicketArticleByTicket(ticketID int) ([]TicketArticle, error) {
 	return ticketArticles, nil
 }
 
-func (c *Client) TicketArticleShow(ticketArticleID int) (TicketArticle, error) {
+func (c *client[T]) TicketArticleShow(ticketArticleID int) (TicketArticle, error) {
 	var ticketArticle TicketArticle
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_articles/%d", ticketArticleID)), nil)
@@ -62,7 +62,7 @@ func (c *Client) TicketArticleShow(ticketArticleID int) (TicketArticle, error) {
 	return ticketArticle, nil
 }
 
-func (c *Client) TicketArticleCreate(t TicketArticle) (TicketArticle, error) {
+func (c *client[T]) TicketArticleCreate(t TicketArticle) (TicketArticle, error) {
 	var ticketArticle TicketArticle
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_articles"), t)

--- a/ticket_priority.go
+++ b/ticket_priority.go
@@ -21,7 +21,7 @@ type TicketPriority struct {
 	UpdatedAt     time.Time `json:"updated_at"`
 }
 
-func (c *Client) TicketPriorityListResult(opts ...Option) *Result[TicketPriority] {
+func (c *client[T]) TicketPriorityListResult(opts ...Option) *Result[TicketPriority] {
 	return &Result[TicketPriority]{
 		res:     nil,
 		resFunc: c.TicketPriorityListWithOptions,
@@ -29,11 +29,11 @@ func (c *Client) TicketPriorityListResult(opts ...Option) *Result[TicketPriority
 	}
 }
 
-func (c *Client) TicketPriorityList() ([]TicketPriority, error) {
+func (c *client[T]) TicketPriorityList() ([]TicketPriority, error) {
 	return c.TicketPriorityListResult().FetchAll()
 }
 
-func (c *Client) TicketPriorityListWithOptions(ro RequestOptions) ([]TicketPriority, error) {
+func (c *client[T]) TicketPriorityListWithOptions(ro RequestOptions) ([]TicketPriority, error) {
 	var ticketPriorities []TicketPriority
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_priorities"), nil)
@@ -50,7 +50,7 @@ func (c *Client) TicketPriorityListWithOptions(ro RequestOptions) ([]TicketPrior
 	return ticketPriorities, nil
 }
 
-func (c *Client) TicketPriorityShow(ticketPriorityID int) (TicketPriority, error) {
+func (c *client[T]) TicketPriorityShow(ticketPriorityID int) (TicketPriority, error) {
 	var ticketPriority TicketPriority
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_priorities/%d", ticketPriorityID)), nil)
@@ -65,7 +65,7 @@ func (c *Client) TicketPriorityShow(ticketPriorityID int) (TicketPriority, error
 	return ticketPriority, nil
 }
 
-func (c *Client) TicketPriorityCreate(t TicketPriority) (TicketPriority, error) {
+func (c *client[T]) TicketPriorityCreate(t TicketPriority) (TicketPriority, error) {
 	var ticketPriority TicketPriority
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_priorities"), t)
@@ -80,7 +80,7 @@ func (c *Client) TicketPriorityCreate(t TicketPriority) (TicketPriority, error) 
 	return ticketPriority, nil
 }
 
-func (c *Client) TicketPriorityUpdate(ticketPriorityID int, t TicketPriority) (TicketPriority, error) {
+func (c *client[T]) TicketPriorityUpdate(ticketPriorityID int, t TicketPriority) (TicketPriority, error) {
 	var ticketPriority TicketPriority
 
 	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_priorities/%d", ticketPriorityID)), t)
@@ -95,7 +95,7 @@ func (c *Client) TicketPriorityUpdate(ticketPriorityID int, t TicketPriority) (T
 	return ticketPriority, nil
 }
 
-func (c *Client) TicketPriorityDelete(ticketPriorityID int) error {
+func (c *client[T]) TicketPriorityDelete(ticketPriorityID int) error {
 
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_priorities/%d", ticketPriorityID)), nil)
 	if err != nil {

--- a/ticket_state.go
+++ b/ticket_state.go
@@ -20,7 +20,7 @@ type TicketState struct {
 	CreatedAt        time.Time `json:"created_at"`
 }
 
-func (c *Client) TicketStateListResult(opts ...Option) *Result[TicketState] {
+func (c *client[T]) TicketStateListResult(opts ...Option) *Result[TicketState] {
 	return &Result[TicketState]{
 		res:     nil,
 		resFunc: c.TicketStateListWithOptions,
@@ -28,11 +28,11 @@ func (c *Client) TicketStateListResult(opts ...Option) *Result[TicketState] {
 	}
 }
 
-func (c *Client) TicketStateList() ([]TicketState, error) {
+func (c *client[T]) TicketStateList() ([]TicketState, error) {
 	return c.TicketStateListResult().FetchAll()
 }
 
-func (c *Client) TicketStateListWithOptions(ro RequestOptions) ([]TicketState, error) {
+func (c *client[T]) TicketStateListWithOptions(ro RequestOptions) ([]TicketState, error) {
 	var ticketStates []TicketState
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_states"), nil)
@@ -49,7 +49,7 @@ func (c *Client) TicketStateListWithOptions(ro RequestOptions) ([]TicketState, e
 	return ticketStates, nil
 }
 
-func (c *Client) TicketStateShow(ticketStateID int) (TicketState, error) {
+func (c *client[T]) TicketStateShow(ticketStateID int) (TicketState, error) {
 	var ticketState TicketState
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_states/%d", ticketStateID)), nil)
@@ -64,7 +64,7 @@ func (c *Client) TicketStateShow(ticketStateID int) (TicketState, error) {
 	return ticketState, nil
 }
 
-func (c *Client) TicketStateCreate(t TicketState) (TicketState, error) {
+func (c *client[T]) TicketStateCreate(t TicketState) (TicketState, error) {
 	var ticketState TicketState
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/ticket_states"), t)
@@ -79,7 +79,7 @@ func (c *Client) TicketStateCreate(t TicketState) (TicketState, error) {
 	return ticketState, nil
 }
 
-func (c *Client) TicketStateUpdate(ticketStateID int, t TicketState) (TicketState, error) {
+func (c *client[T]) TicketStateUpdate(ticketStateID int, t TicketState) (TicketState, error) {
 	var ticketState TicketState
 
 	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_states/%d", ticketStateID)), t)
@@ -94,7 +94,7 @@ func (c *Client) TicketStateUpdate(ticketStateID int, t TicketState) (TicketStat
 	return ticketState, nil
 }
 
-func (c *Client) TicketStateDelete(ticketStateID int) error {
+func (c *client[T]) TicketStateDelete(ticketStateID int) error {
 
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/ticket_states/%d", ticketStateID)), nil)
 	if err != nil {

--- a/ticket_tag.go
+++ b/ticket_tag.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-func (c *Client) TicketTagByTicket(ticketID int) ([]Tag, error) {
+func (c *client[T]) TicketTagByTicket(ticketID int) ([]Tag, error) {
 	var tags struct {
 		Tags []string
 	}

--- a/ticket_test.go
+++ b/ticket_test.go
@@ -95,7 +95,7 @@ func TestTicketCreate(t *testing.T) {
 	}
 
 	// these values might not map to your zammad instance.
-	ticket := Ticket{
+	ticket := Ticket[struct{}]{
 		Title:    "test: test",
 		Group:    "Sysadmin",
 		Customer: "bram",

--- a/types.go
+++ b/types.go
@@ -9,18 +9,16 @@ type (
 	// Client is used to query Zammad. It is safe to use concurrently. If you (inadvertly) added
 	// multiple authencation options that will be applied in the order, basic auth, token based, and
 	// then oauth. Where the last one set, wins.
-	Client struct {
+	client[T any] struct {
 		Client   Doer
 		Username string
 		Password string
 		Token    string
 		OAuth    string
 		Url      string
-		// FromFunc is used to set the From HTTP header, if you want to act on behalf of another user.
-		// See https://docs.zammad.org/en/latest/api/intro.html#actions-on-behalf-of-other-users. If not nil
-		// *and* returning a non empty string, this value will be used in the request.
 		FromFunc func() string
 	}
+	Client = client[struct{}]
 
 	// ErrorResponse is the response returned by Zammad when an error occured.
 	ErrorResponse struct {

--- a/user.go
+++ b/user.go
@@ -20,7 +20,7 @@ type User struct {
 }
 
 // UserMe returns the current authenticated user.
-func (c *Client) UserMe() (User, error) {
+func (c *client[T]) UserMe() (User, error) {
 	var user User
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/users/me"), nil)
@@ -35,7 +35,7 @@ func (c *Client) UserMe() (User, error) {
 	return user, nil
 }
 
-func (c *Client) UserListResult(opts ...Option) *Result[User] {
+func (c *client[T]) UserListResult(opts ...Option) *Result[User] {
 	return &Result[User]{
 		res:     nil,
 		resFunc: c.UserListWithOptions,
@@ -43,11 +43,11 @@ func (c *Client) UserListResult(opts ...Option) *Result[User] {
 	}
 }
 
-func (c *Client) UserList() ([]User, error) {
+func (c *client[T]) UserList() ([]User, error) {
 	return c.UserListResult().FetchAll()
 }
 
-func (c *Client) UserListWithOptions(ro RequestOptions) ([]User, error) {
+func (c *client[T]) UserListWithOptions(ro RequestOptions) ([]User, error) {
 	var users []User
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, "/api/v1/users"), nil)
@@ -64,7 +64,7 @@ func (c *Client) UserListWithOptions(ro RequestOptions) ([]User, error) {
 	return users, nil
 }
 
-func (c *Client) UserSearch(query string, limit int) ([]User, error) {
+func (c *client[T]) UserSearch(query string, limit int) ([]User, error) {
 	var users []User
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/search?query=%s&limit=%d", url.QueryEscape(query), limit)), nil)
@@ -79,7 +79,7 @@ func (c *Client) UserSearch(query string, limit int) ([]User, error) {
 	return users, nil
 }
 
-func (c *Client) UserShow(userID int) (User, error) {
+func (c *client[T]) UserShow(userID int) (User, error) {
 	var user User
 
 	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/%d", userID)), nil)
@@ -94,7 +94,7 @@ func (c *Client) UserShow(userID int) (User, error) {
 	return user, nil
 }
 
-func (c *Client) UserCreate(u User) (User, error) {
+func (c *client[T]) UserCreate(u User) (User, error) {
 	var user User
 
 	req, err := c.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", c.Url, "/api/v1/users"), u)
@@ -109,7 +109,7 @@ func (c *Client) UserCreate(u User) (User, error) {
 	return user, nil
 }
 
-func (c *Client) UserUpdate(userID int, u User) (User, error) {
+func (c *client[T]) UserUpdate(userID int, u User) (User, error) {
 	var user User
 
 	req, err := c.NewRequest(http.MethodPut, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/%d", userID)), u)
@@ -124,7 +124,7 @@ func (c *Client) UserUpdate(userID int, u User) (User, error) {
 	return user, nil
 }
 
-func (c *Client) UserDelete(userID int) error {
+func (c *client[T]) UserDelete(userID int) error {
 
 	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/users/%d", userID)), nil)
 	if err != nil {

--- a/user_access_token.go
+++ b/user_access_token.go
@@ -57,7 +57,7 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (c *Client) UserAccessTokenList() ([]UserAccessToken, error) {
+func (c *client[T]) UserAccessTokenList() ([]UserAccessToken, error) {
 	type TockList struct {
 		Tokens      []UserAccessToken `json:"tokens"`
 		Permissions []Permission      `json:"permissions"`
@@ -82,7 +82,7 @@ func (c *Client) UserAccessTokenList() ([]UserAccessToken, error) {
 	return userAccessTokens, nil
 }
 
-func (c *Client) UserAccessTokenCreate(t UserAccessToken) (UserAccessToken, error) {
+func (c *client[T]) UserAccessTokenCreate(t UserAccessToken) (UserAccessToken, error) {
 	var userAccessToken UserAccessToken
 
 	req, err := c.NewRequest("POST", fmt.Sprintf("%s%s", c.Url, "/api/v1/user_access_token"), t)
@@ -97,7 +97,7 @@ func (c *Client) UserAccessTokenCreate(t UserAccessToken) (UserAccessToken, erro
 	return userAccessToken, nil
 }
 
-func (c *Client) UserAccessTokenDelete(tokenID int) error {
+func (c *client[T]) UserAccessTokenDelete(tokenID int) error {
 
 	req, err := c.NewRequest("DELETE", fmt.Sprintf("%s%s", c.Url, fmt.Sprintf("/api/v1/user_access_token/%d", tokenID)), nil)
 	if err != nil {


### PR DESCRIPTION
Hi There.

I noticed your client doesnt have any way to access Custom Fields or Objects.
I've found a way to implement this without any breaking Changes. And thought maybe its worth sharing this with the community
# Usage

```go
type CustomFields struct {
	DeviceNumber string `json:"device_number,omitempty"`
}

func main() {
	// This is just a playground for testing the library. It is not meant to be used as an example.
	// See the documentation and the tests for that.
	client := zammad.NewWithCustomTicketFields[CustomFields]("http://<redacted>")
	client.Token = "<redacted>"

	res, err := client.TicketShow(140)
	if err != nil {
		panic(err)
	}

	println(res.Title)
	println(res.CustomFields.DeviceNumber)



```
# Notes and Considerations
- The Commit seems touching quite a lot but thats caused by replacing `Client` with `Client[T]`
- The way i got Unmarshaling working is quite hacky - but i havent found a way for generics to work as embedded Types.


Best Regards,
Michael